### PR TITLE
MDNS service addresses incorrectly assigned during update

### DIFF
--- a/moonraker/components/zeroconf.py
+++ b/moonraker/components/zeroconf.py
@@ -219,7 +219,7 @@ class ZeroconfRegistrar:
                     self.zc_service_props["ip"] = str(ip_addr)
                 except ValueError:
                     pass
-            self.service_info.addresses = addresses
+            self.addresses = addresses
             self.service_info = AsyncServiceInfo(
                     ZC_SERVICE_TYPE,
                     self.zc_service_name,


### PR DESCRIPTION
The zeroconf component may be initialised before IP address assignment. To address this, `_update_service` is registered as a callback upon network changes, however there is an incorrect assignment in the function, which results in the service's addresses never being actually updated. This means that the machine will not be accessible via their MDNS .local domain (unless Moonraker is restarted when an IP has been assigned). 